### PR TITLE
Add status.claude.com polling for service disruption display

### DIFF
--- a/ClaudeUsage.xcodeproj/project.pbxproj
+++ b/ClaudeUsage.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		002 /* UsageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 102 /* UsageManager.swift */; };
 		003 /* UsageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 103 /* UsageView.swift */; };
 		004 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 104 /* Assets.xcassets */; };
+		005 /* StatusManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 106 /* StatusManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -20,6 +21,7 @@
 		103 /* UsageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageView.swift; sourceTree = "<group>"; };
 		104 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		105 /* ClaudeUsage.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ClaudeUsage.entitlements; sourceTree = "<group>"; };
+		106 /* StatusManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -45,6 +47,7 @@
 			isa = PBXGroup;
 			children = (
 				101 /* ClaudeUsageApp.swift */,
+				106 /* StatusManager.swift */,
 				102 /* UsageManager.swift */,
 				103 /* UsageView.swift */,
 				104 /* Assets.xcassets */,
@@ -131,6 +134,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				001 /* ClaudeUsageApp.swift in Sources */,
+				005 /* StatusManager.swift in Sources */,
 				002 /* UsageManager.swift in Sources */,
 				003 /* UsageView.swift in Sources */,
 			);

--- a/ClaudeUsage/ClaudeUsageApp.swift
+++ b/ClaudeUsage/ClaudeUsageApp.swift
@@ -17,6 +17,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var statusItem: NSStatusItem?
     var popover: NSPopover?
     var usageManager = UsageManager()
+    var statusManager = StatusManager()
     var timer: Timer?
     var cancellables = Set<AnyCancellable>()
 
@@ -51,19 +52,29 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in self?.updateStatusItem() }
             .store(in: &cancellables)
+
+        statusManager.$disruptions
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in self?.updateStatusItem() }
+            .store(in: &cancellables)
     }
 
     @objc func handleWake() {
         // Delay refresh after wake to allow keychain to unlock
         Task {
             try? await Task.sleep(nanoseconds: 3_000_000_000) // 3 seconds
+            async let statusRefresh: () = statusManager.refresh()
             await usageManager.refresh()
+            _ = await statusRefresh
         }
     }
 
     func startFetching() {
         // Initial fetch and update check
         Task {
+            // Status fetch can run immediately (no auth needed)
+            async let statusFetch: () = statusManager.refresh()
+
             // If system recently booted (within 60 seconds), wait before accessing keychain
             // The keychain/login system takes time to be fully available after boot
             let uptime = ProcessInfo.processInfo.systemUptime
@@ -74,12 +85,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
             await usageManager.refresh()
             await usageManager.checkForUpdates()
+            _ = await statusFetch
         }
 
         // Refresh every 5 minutes
         timer = Timer.scheduledTimer(withTimeInterval: 300, repeats: true) { [weak self] _ in
             Task { @MainActor in
+                async let statusRefresh: () = self?.statusManager.refresh() ?? ()
                 await self?.usageManager.refresh()
+                _ = await statusRefresh
             }
         }
     }
@@ -98,7 +112,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         popover = NSPopover()
         popover?.contentSize = NSSize(width: 280, height: 320)
         popover?.behavior = .transient
-        popover?.contentViewController = NSHostingController(rootView: UsageView(manager: usageManager))
+        popover?.contentViewController = NSHostingController(rootView: UsageView(manager: usageManager, statusManager: statusManager))
     }
     
     func updateStatusItem() {
@@ -107,11 +121,19 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         if let usage = usageManager.usage {
             let sessionPct = usage.sessionPercentage
             let emoji = usageManager.statusEmoji
-            button.title = "\(emoji) \(sessionPct)%"
+            var title = "\(emoji) \(sessionPct)%"
+            if let badge = statusManager.badgeEmoji {
+                title += " \(badge)"
+            }
+            button.title = title
         } else if usageManager.error != nil {
-            button.title = "❌"
+            var title = "❌"
+            if let badge = statusManager.badgeEmoji { title += " \(badge)" }
+            button.title = title
         } else {
-            button.title = "⏳"
+            var title = "⏳"
+            if let badge = statusManager.badgeEmoji { title += " \(badge)" }
+            button.title = title
         }
     }
     

--- a/ClaudeUsage/StatusManager.swift
+++ b/ClaudeUsage/StatusManager.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+struct ComponentDisruption {
+    let name: String
+    let status: String
+}
+
+@MainActor
+class StatusManager: ObservableObject {
+    @Published var disruptions: [ComponentDisruption] = []
+
+    private static let trackedComponentIDs: Set<String> = [
+        "0qbwn08sd68x", // claude.ai
+        "k8w3r06qmzrp", // Claude API
+        "yyzkbfz2thpt", // Claude Code
+    ]
+
+    private lazy var urlSession: URLSession = {
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 10
+        config.timeoutIntervalForResource = 30
+        return URLSession(configuration: config)
+    }()
+
+    var badgeEmoji: String? {
+        guard !disruptions.isEmpty else { return nil }
+        let hasOutage = disruptions.contains { disruption in
+            disruption.status == "major_outage" || disruption.status == "partial_outage"
+        }
+        return hasOutage ? "🔥" : "⚠️"
+    }
+
+    func refresh() async {
+        guard let url = URL(string: "https://status.claude.com/api/v2/components.json") else { return }
+
+        do {
+            let (data, _) = try await urlSession.data(from: url)
+
+            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let components = json["components"] as? [[String: Any]] else {
+                return
+            }
+
+            disruptions = components.compactMap { component in
+                guard let id = component["id"] as? String,
+                      let name = component["name"] as? String,
+                      let status = component["status"] as? String,
+                      Self.trackedComponentIDs.contains(id),
+                      status != "operational" else {
+                    return nil
+                }
+                return ComponentDisruption(name: name, status: status)
+            }.sorted { $0.name < $1.name }
+        } catch {
+            // Silent failure — leave disruptions unchanged
+        }
+    }
+}

--- a/ClaudeUsage/UsageView.swift
+++ b/ClaudeUsage/UsageView.swift
@@ -4,6 +4,7 @@ import ServiceManagement
 
 struct UsageView: View {
     @ObservedObject var manager: UsageManager
+    @ObservedObject var statusManager: StatusManager
     @Environment(\.openURL) var openURL
     @State private var launchAtLogin: Bool = {
         if #available(macOS 13.0, *) {
@@ -60,6 +61,17 @@ struct UsageView: View {
                 loadingView()
             }
             
+            // Service disruptions (shown in all states)
+            if !statusManager.disruptions.isEmpty {
+                VStack(spacing: 8) {
+                    ForEach(statusManager.disruptions, id: \.name) { disruption in
+                        DisruptionRow(disruption: disruption)
+                    }
+                }
+                .padding(.horizontal)
+                .padding(.vertical, 8)
+            }
+
             Divider()
             
             // Footer
@@ -404,6 +416,71 @@ struct OverageRow: View {
     }
 }
 
+struct DisruptionRow: View {
+    let disruption: ComponentDisruption
+    @Environment(\.openURL) var openURL
+
+    private var color: Color {
+        switch disruption.status {
+        case "major_outage", "partial_outage":
+            return .red
+        default:
+            return .orange
+        }
+    }
+
+    private var displayStatus: String {
+        switch disruption.status {
+        case "degraded_performance":
+            return "degraded"
+        case "major_outage":
+            return "major outage"
+        case "partial_outage":
+            return "partial outage"
+        case "under_maintenance":
+            return "maintenance"
+        default:
+            return disruption.status
+        }
+    }
+
+    private var emoji: String {
+        switch disruption.status {
+        case "major_outage", "partial_outage":
+            return "🔥"
+        default:
+            return "⚠️"
+        }
+    }
+
+    var body: some View {
+        Button(action: {
+            openURL(URL(string: "https://status.claude.com")!)
+        }) {
+            HStack {
+                Text("\(emoji) \(disruption.name)")
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                Spacer()
+                Text(displayStatus)
+                    .font(.caption)
+                    .foregroundColor(color)
+            }
+            .padding(12)
+            .background(Color(NSColor.controlBackgroundColor))
+            .cornerRadius(8)
+            .overlay(
+                Rectangle()
+                    .fill(color)
+                    .frame(width: 3),
+                alignment: .leading
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+        }
+        .buttonStyle(.plain)
+    }
+}
+
 #Preview {
-    UsageView(manager: UsageManager())
+    UsageView(manager: UsageManager(), statusManager: StatusManager())
 }


### PR DESCRIPTION
## Summary

- Polls `status.claude.com/api/v2/components.json` on the existing 5-minute timer to detect service disruptions for Claude API, Claude Code, and claude.ai
- Shows disrupted services as clickable rows in the dropdown (opens status.claude.com)
- Appends a badge emoji to the menu bar icon when disruptions exist (⚠️ for degraded/maintenance, 🔥 for outages)
- Silent when all systems are operational — no UI changes when everything is fine

## Changes

- **New:** `StatusManager.swift` — `@MainActor ObservableObject` that fetches component status, filters to 3 tracked services, publishes non-operational disruptions
- **Modified:** `ClaudeUsageApp.swift` — wires `StatusManager` into the existing polling timer, wake handler, and Combine observers; appends disruption badge to menu bar title
- **Modified:** `UsageView.swift` — adds `DisruptionRow` struct and conditional disruption section above the footer
- **Modified:** `project.pbxproj` — adds `StatusManager.swift` to build target

## Test plan

- [ ] Build and run with all services operational — verify no visual changes to menu bar or dropdown
- [ ] Temporarily invert the filter in `StatusManager.swift` (`status == "operational"` instead of `!=`) to simulate disruptions, rebuild, and verify:
  - Menu bar shows badge emoji appended after percentage
  - Dropdown shows disruption rows with component names and status text
  - Clicking a disruption row opens status.claude.com
  - Badge appears in error and loading states too
- [ ] Revert the test change